### PR TITLE
(Fix #96) Recognize sound_file_name on first load

### DIFF
--- a/src/writracker/recorder/dataio.py
+++ b/src/writracker/recorder/dataio.py
@@ -189,16 +189,17 @@ def load_targets(targets_file_path):
         df = pd.read_csv(targets_file_path, converters=_targets_file_converters)
 
     if not {'target_id', 'target'}.issubset(set(list(df))):  # Check targets file format
-        return None, ("Wrong targets file format",
+        return None, None, ("Wrong targets file format",
                       "targets file must contain the following fields: 'target_id', 'target'.\nOptional field: 'sound_file_name'")
 
+    has_sound_file_column = 'sound_file_name' in set(list(df))
     targets = []
 
     for index, row in df.iterrows():
         sound_file_name = row["sound_file_name"] if ("sound_file_name" in df.columns) and str(row["sound_file_name"]) != 'nan' else ""
         targets.append(Target(row["target_id"], row["target"].strip(), sound_file_name))
 
-    return targets, None
+    return targets, has_sound_file_column, None
 
 
 def _null_converter(v):

--- a/src/writracker/recorder/recorder.py
+++ b/src/writracker/recorder/recorder.py
@@ -754,7 +754,7 @@ class MainWindow(QMainWindow):  # inherits QMainWindow, can equally define windo
         Read targets file, create target objects, and insert to the list. Also fills the comboBox (goto)
         """
 
-        targets, err_msg = dataio.load_targets(targets_file_path)
+        targets, has_sound_file_column, err_msg = dataio.load_targets(targets_file_path)
         if err_msg is not None:
             _warning(err_msg[0], err_msg[1])
             raise IOError  # bad targets file format
@@ -765,6 +765,7 @@ class MainWindow(QMainWindow):  # inherits QMainWindow, can equally define windo
             self.combox_targets.addItem(str(target.id)+"-"+target.value)
 
         self.targets_file_name = os.path.abspath(targets_file_path)
+        self.allow_sound_play = has_sound_file_column
 
         return True
 


### PR DESCRIPTION
allow_sound_play wasn't fully based on the column header, but on the
file name for each target. Parse column name 'sound_file_name' on
targets load. If exists, enable mp3 dir load.